### PR TITLE
Running "cargo fmt" and improving Plugin::instantiate

### DIFF
--- a/lv2-core/lv2-core-derive/src/lib.rs
+++ b/lv2-core/lv2-core-derive/src/lib.rs
@@ -1,4 +1,4 @@
-#![recursion_limit="128"]
+#![recursion_limit = "128"]
 
 extern crate proc_macro;
 extern crate syn;

--- a/lv2-core/src/feature/descriptor.rs
+++ b/lv2-core/src/feature/descriptor.rs
@@ -1,17 +1,17 @@
-use std::os::raw::{c_void};
+use std::ffi::CStr;
 use std::fmt;
 use std::marker::PhantomData;
-use std::ffi::CStr;
+use std::os::raw::c_void;
 
-use crate::uri::{Uri, UriBound};
 use crate::feature::feature::Feature;
 use crate::feature::feature::RawFeatureDescriptor;
+use crate::uri::{Uri, UriBound};
 
 #[derive(Copy, Clone)]
 pub struct FeatureDescriptor<'a> {
     pub(crate) inner: ::lv2_core_sys::LV2_Feature,
     uri_len: usize,
-    _lifetime: PhantomData<&'a u8>
+    _lifetime: PhantomData<&'a u8>,
 }
 
 impl<'a> FeatureDescriptor<'a> {
@@ -24,7 +24,10 @@ impl<'a> FeatureDescriptor<'a> {
             feature as *const T as *const c_void as *mut c_void
         };
         FeatureDescriptor {
-            inner: ::lv2_core_sys::LV2_Feature { URI: uri.as_ptr(), data },
+            inner: ::lv2_core_sys::LV2_Feature {
+                URI: uri.as_ptr(),
+                data,
+            },
             uri_len: uri.to_bytes_with_nul().len(),
             _lifetime: PhantomData,
         }
@@ -36,7 +39,9 @@ impl<'a> FeatureDescriptor<'a> {
         let uri_len = CStr::from_ptr(inner.URI).to_bytes_with_nul().len();
 
         FeatureDescriptor {
-            inner, uri_len, _lifetime: PhantomData
+            inner,
+            uri_len,
+            _lifetime: PhantomData,
         }
     }
 

--- a/lv2-core/src/feature/feature.rs
+++ b/lv2-core/src/feature/feature.rs
@@ -1,5 +1,5 @@
-use crate::uri::UriBound;
 use crate::feature::descriptor::FeatureDescriptor;
+use crate::uri::UriBound;
 
 /// Represents extension data for a given feature.
 /// # Unsafety
@@ -20,5 +20,5 @@ unsafe impl<F: Feature> UriBound for F {
 
 #[repr(transparent)]
 pub struct RawFeatureDescriptor {
-    pub(crate) inner: ::lv2_core_sys::LV2_Feature
+    pub(crate) inner: ::lv2_core_sys::LV2_Feature,
 }

--- a/lv2-core/src/feature/list.rs
+++ b/lv2-core/src/feature/list.rs
@@ -1,20 +1,25 @@
-use crate::feature::feature::RawFeatureDescriptor;
 use crate::feature::descriptor::FeatureDescriptor;
-use std::marker::PhantomData;
 use crate::feature::feature::Feature;
+use crate::feature::feature::RawFeatureDescriptor;
+use std::marker::PhantomData;
 
 pub struct FeatureList<'a> {
     inner: *const *const ::lv2_core_sys::LV2_Feature,
-    _lifetime: PhantomData<&'a ()>
+    _lifetime: PhantomData<&'a ()>,
 }
 
 impl<'a> FeatureList<'a> {
     pub unsafe fn from_raw(inner: *const *const RawFeatureDescriptor) -> FeatureList<'a> {
-        Self { inner: inner as _, _lifetime: PhantomData }
+        Self {
+            inner: inner as _,
+            _lifetime: PhantomData,
+        }
     }
 
     pub fn find<F: Feature>(&self) -> Option<&'a F> {
-        self.into_iter().filter_map(FeatureDescriptor::into_feature_ref::<F>).next()
+        self.into_iter()
+            .filter_map(FeatureDescriptor::into_feature_ref::<F>)
+            .next()
     }
 }
 
@@ -25,22 +30,26 @@ impl<'a, 'b> IntoIterator for &'b FeatureList<'a> {
     fn into_iter(self) -> <Self as IntoIterator>::IntoIter {
         FeatureIter {
             ptr: self.inner,
-            _lifetime: PhantomData
+            _lifetime: PhantomData,
         }
     }
 }
 
 pub struct FeatureIter<'a> {
     ptr: *const *const ::lv2_core_sys::LV2_Feature,
-    _lifetime: PhantomData<&'a ()>
+    _lifetime: PhantomData<&'a ()>,
 }
 
 impl<'a> Iterator for FeatureIter<'a> {
     type Item = FeatureDescriptor<'a>;
 
     fn next(&mut self) -> Option<<Self as Iterator>::Item> {
-        if self.ptr.is_null() { return None }
-        if unsafe { *self.ptr }.is_null() { return None }
+        if self.ptr.is_null() {
+            return None;
+        }
+        if unsafe { *self.ptr }.is_null() {
+            return None;
+        }
 
         let feature = unsafe { FeatureDescriptor::from_raw(*self.ptr as _) };
         self.ptr = unsafe { self.ptr.offset(1) };

--- a/lv2-core/src/lib.rs
+++ b/lv2-core/src/lib.rs
@@ -1,14 +1,17 @@
-mod feature;
-mod port;
-mod plugin_descriptor;
+pub extern crate lv2_core_sys as sys;
+pub extern crate lv2_core_derive as derive;
+
 mod extension_data;
+mod feature;
+mod plugin_descriptor;
+mod port;
 
-pub mod ports;
 pub mod features;
-pub mod uri;
 pub mod plugin;
+pub mod ports;
+pub mod uri;
 
-pub use self::feature::*;
-pub use self::port::*;
-pub use self::plugin_descriptor::*;
 pub use self::extension_data::*;
+pub use self::feature::*;
+pub use self::plugin_descriptor::*;
+pub use self::port::*;

--- a/lv2-core/src/plugin.rs
+++ b/lv2-core/src/plugin.rs
@@ -1,9 +1,9 @@
-mod ports;
-mod plugin;
 mod features;
+mod plugin;
+mod ports;
 
-pub use ports::*;
-pub use plugin::*;
 pub use features::*;
+pub use plugin::*;
+pub use ports::*;
 
 pub use lv2_core_derive::*;

--- a/lv2-core/src/plugin/features.rs
+++ b/lv2-core/src/plugin/features.rs
@@ -4,13 +4,15 @@ use std::error::Error;
 use std::fmt::{self, Debug, Display, Formatter};
 
 pub enum FeatureResolutionError {
-    MissingRequiredFeature { uri: &'static Uri }
+    MissingRequiredFeature { uri: &'static Uri },
 }
 
 impl Debug for FeatureResolutionError {
     fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
         match self {
-            FeatureResolutionError::MissingRequiredFeature { uri } => write!(f, "Missing required feature: {}", uri)
+            FeatureResolutionError::MissingRequiredFeature { uri } => {
+                write!(f, "Missing required feature: {}", uri)
+            }
         }
     }
 }
@@ -25,12 +27,16 @@ impl Display for FeatureResolutionError {
 impl Error for FeatureResolutionError {}
 
 pub trait Lv2Features: Sized {
-    fn from_feature_list(feature_list: FeatureList<'static>) -> Result<Self, FeatureResolutionError>;
+    fn from_feature_list(
+        feature_list: FeatureList<'static>,
+    ) -> Result<Self, FeatureResolutionError>;
 }
 
 impl Lv2Features for () {
     #[inline(always)]
-    fn from_feature_list(_feature_list: FeatureList<'static>) -> Result<Self, FeatureResolutionError> {
+    fn from_feature_list(
+        _feature_list: FeatureList<'static>,
+    ) -> Result<Self, FeatureResolutionError> {
         Ok(())
     }
 }

--- a/lv2-core/src/plugin/ports.rs
+++ b/lv2-core/src/plugin/ports.rs
@@ -1,9 +1,9 @@
 use crate::PortType;
-use std::ptr::NonNull;
 use std::ops::{Deref, DerefMut};
+use std::ptr::NonNull;
 
 pub struct InputPort<T: PortType> {
-    port: T::InputPortType
+    port: T::InputPortType,
 }
 
 impl<T: PortType> Deref for InputPort<T> {
@@ -16,7 +16,7 @@ impl<T: PortType> Deref for InputPort<T> {
 }
 
 pub struct OutputPort<T: PortType> {
-    port: T::OutputPortType
+    port: T::OutputPortType,
 }
 
 impl<T: PortType> Deref for OutputPort<T> {
@@ -42,14 +42,18 @@ pub trait PortHandle: Sized {
 impl<T: PortType> PortHandle for InputPort<T> {
     #[inline]
     unsafe fn from_raw(pointer: *mut (), sample_count: u32) -> Self {
-        Self { port: T::input_from_raw(NonNull::new_unchecked(pointer), sample_count) }
+        Self {
+            port: T::input_from_raw(NonNull::new_unchecked(pointer), sample_count),
+        }
     }
 }
 
 impl<T: PortType> PortHandle for OutputPort<T> {
     #[inline]
     unsafe fn from_raw(pointer: *mut (), sample_count: u32) -> Self {
-        Self { port: T::output_from_raw(NonNull::new_unchecked(pointer), sample_count) }
+        Self {
+            port: T::output_from_raw(NonNull::new_unchecked(pointer), sample_count),
+        }
     }
 }
 

--- a/lv2-core/src/plugin_descriptor.rs
+++ b/lv2-core/src/plugin_descriptor.rs
@@ -1,19 +1,28 @@
 use std::os::raw::c_char;
 
-use std::ffi::c_void;
+use crate::sys::LV2_Handle;
 use crate::feature::RawFeatureDescriptor;
+use std::ffi::c_void;
 
 #[allow(non_snake_case)]
 #[repr(C)]
 pub struct PluginDescriptor<T> {
     pub URI: *const c_char,
-    pub instantiate: Option<unsafe extern "C" fn(descriptor: *const PluginDescriptor<T>, sample_rate: f64, bundle_path: *const c_char, features: *const *const RawFeatureDescriptor) -> *mut T>,
-    pub connect_port: Option<unsafe extern "C" fn(instance: *mut T, port: u32, data_location: *mut c_void)>,
+    pub instantiate: Option<
+        unsafe extern "C" fn(
+            descriptor: *const PluginDescriptor<T>,
+            sample_rate: f64,
+            bundle_path: *const c_char,
+            features: *const *const RawFeatureDescriptor,
+        ) -> LV2_Handle,
+    >,
+    pub connect_port:
+        Option<unsafe extern "C" fn(instance: *mut T, port: u32, data_location: *mut c_void)>,
     pub activate: Option<unsafe extern "C" fn(instance: *mut T)>,
     pub run: Option<unsafe extern "C" fn(instance: *mut T, sample_count: u32)>,
     pub deactivate: Option<unsafe extern "C" fn(instance: *mut T)>,
     pub cleanup: Option<unsafe extern "C" fn(instance: *mut T)>,
-    pub extension_data: Option<unsafe extern "C" fn(uri: *const c_char) -> *const c_void>
+    pub extension_data: Option<unsafe extern "C" fn(uri: *const c_char) -> *const c_void>,
 }
 
 impl<T> PluginDescriptor<T> {
@@ -28,5 +37,5 @@ unsafe impl<T> Sync for PluginDescriptor<T> {}
 
 #[repr(transparent)]
 pub struct PluginHandle {
-    _private: c_void
+    _private: c_void,
 }

--- a/lv2-core/src/port.rs
+++ b/lv2-core/src/port.rs
@@ -20,5 +20,5 @@ pub trait PortType: 'static + Sized {
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub enum PortDirection {
     Input,
-    Output
+    Output,
 }

--- a/lv2-core/src/ports/audio.rs
+++ b/lv2-core/src/ports/audio.rs
@@ -1,6 +1,6 @@
 use crate::port::PortType;
-use std::ptr::NonNull;
 use crate::ports::base::{InputSampledData, OutputSampledData};
+use std::ptr::NonNull;
 
 pub struct Audio;
 

--- a/lv2-core/src/ports/base.rs
+++ b/lv2-core/src/ports/base.rs
@@ -2,13 +2,16 @@ use std::ptr::NonNull;
 
 pub struct InputSampledData<T: Copy> {
     pointer: NonNull<T>,
-    sample_count: u32
+    sample_count: u32,
 }
 
 impl<T: Copy> InputSampledData<T> {
     #[inline]
     pub unsafe fn new(pointer: NonNull<()>, sample_count: u32) -> Self {
-        Self { pointer: pointer.cast(), sample_count }
+        Self {
+            pointer: pointer.cast(),
+            sample_count,
+        }
     }
 
     #[inline]
@@ -29,24 +32,31 @@ impl<T: Copy> InputSampledData<T> {
 
 pub struct OutputSampledData<T: Copy> {
     pointer: NonNull<T>,
-    sample_count: u32
+    sample_count: u32,
 }
 
 impl<T: Copy> OutputSampledData<T> {
     #[inline]
     pub unsafe fn new(pointer: NonNull<()>, sample_count: u32) -> Self {
-        Self { pointer: pointer.cast(), sample_count }
+        Self {
+            pointer: pointer.cast(),
+            sample_count,
+        }
     }
 
     #[inline]
     pub fn put(&self, value: T, index: usize) {
-        let slice = unsafe { ::std::slice::from_raw_parts_mut(self.pointer.as_ptr(), self.sample_count as usize) };
+        let slice = unsafe {
+            ::std::slice::from_raw_parts_mut(self.pointer.as_ptr(), self.sample_count as usize)
+        };
         slice[index] = value
     }
 
     #[inline]
-    pub fn collect_from<I: IntoIterator<Item=T>>(&self, iterable: I) {
-        let slice = unsafe { ::std::slice::from_raw_parts_mut(self.pointer.as_ptr(), self.sample_count as usize) };
+    pub fn collect_from<I: IntoIterator<Item = T>>(&self, iterable: I) {
+        let slice = unsafe {
+            ::std::slice::from_raw_parts_mut(self.pointer.as_ptr(), self.sample_count as usize)
+        };
 
         for (output, input) in slice.iter_mut().zip(iterable) {
             *output = input
@@ -55,9 +65,13 @@ impl<T: Copy> OutputSampledData<T> {
 
     #[inline]
     pub fn fill(&self, value: T) {
-        let slice = unsafe { ::std::slice::from_raw_parts_mut(self.pointer.as_ptr(), self.sample_count as usize) };
+        let slice = unsafe {
+            ::std::slice::from_raw_parts_mut(self.pointer.as_ptr(), self.sample_count as usize)
+        };
 
-        for output in slice.iter_mut() { *output = value }
+        for output in slice.iter_mut() {
+            *output = value
+        }
     }
 
     #[inline]

--- a/lv2-core/src/ports/control.rs
+++ b/lv2-core/src/ports/control.rs
@@ -2,7 +2,7 @@ use crate::port::PortType;
 use std::ptr::NonNull;
 
 pub struct Control {
-    pointer: NonNull<f32>
+    pointer: NonNull<f32>,
 }
 
 impl Control {
@@ -20,10 +20,14 @@ impl PortType for Control {
 
     #[inline]
     unsafe fn input_from_raw(pointer: NonNull<()>, _sample_count: u32) -> Self::InputPortType {
-        Self { pointer: pointer.cast() }
+        Self {
+            pointer: pointer.cast(),
+        }
     }
 
     unsafe fn output_from_raw(pointer: NonNull<()>, _sample_count: u32) -> Self::OutputPortType {
-        Self { pointer: pointer.cast() }
+        Self {
+            pointer: pointer.cast(),
+        }
     }
 }

--- a/lv2-core/src/ports/cv.rs
+++ b/lv2-core/src/ports/cv.rs
@@ -1,6 +1,6 @@
 use crate::port::PortType;
-use std::ptr::NonNull;
 use crate::ports::base::{InputSampledData, OutputSampledData};
+use std::ptr::NonNull;
 
 pub struct CV;
 

--- a/lv2-core/src/uri.rs
+++ b/lv2-core/src/uri.rs
@@ -6,7 +6,7 @@ use std::ops::{Deref, DerefMut};
 
 #[derive(Debug, Clone)]
 pub enum UriError {
-    CStrNulError(NulError)
+    CStrNulError(NulError),
 }
 
 impl Error for UriError {}
@@ -15,7 +15,7 @@ impl fmt::Display for UriError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str("Invalid URI String: ")?;
         match self {
-            UriError::CStrNulError(e) => fmt::Display::fmt(e, f)
+            UriError::CStrNulError(e) => fmt::Display::fmt(e, f),
         }
     }
 }
@@ -23,7 +23,7 @@ impl fmt::Display for UriError {
 // TODO: Check Eq impl ?
 #[derive(PartialEq, Eq)]
 pub struct Uri {
-    inner: CStr
+    inner: CStr,
 }
 
 impl Uri {
@@ -132,7 +132,7 @@ impl<T: AsUriRef> AsUriRef for Result<T, UriError> {
     fn as_uri(&self) -> Result<&Uri, UriError> {
         match self {
             Ok(uri) => uri.as_uri(),
-            Err(e) => Err(e.clone())
+            Err(e) => Err(e.clone()),
         }
     }
 }
@@ -151,7 +151,7 @@ impl AsUriRef for CString {
 
 #[derive(PartialEq, Eq)]
 pub struct UriBuf {
-    inner: CString
+    inner: CString,
 }
 
 impl UriBuf {

--- a/lv2/examples/amplifier/lib.rs
+++ b/lv2/examples/amplifier/lib.rs
@@ -1,5 +1,8 @@
+use std::ffi::CStr;
+
+use lv2::core::plugin::{lv2_descriptors, InputPort, Lv2Ports, OutputPort, Plugin};
 use lv2::core::ports::{Audio, Control};
-use lv2::core::plugin::{InputPort, OutputPort, Lv2Ports, Plugin, lv2_descriptors};
+use lv2::core::uri::Uri;
 
 struct Amp;
 
@@ -7,12 +10,16 @@ struct Amp;
 struct AmpPorts {
     gain: InputPort<Control>,
     input: InputPort<Audio>,
-    output: OutputPort<Audio>
+    output: OutputPort<Audio>,
 }
 
 #[inline]
 fn db_co(g: f32) -> f32 {
-    if g > -90.0 { 10f32.powf(g * 0.05) } else { 0.0 }
+    if g > -90.0 {
+        10f32.powf(g * 0.05)
+    } else {
+        0.0
+    }
 }
 
 impl Plugin for Amp {
@@ -20,7 +27,9 @@ impl Plugin for Amp {
     type Features = ();
 
     #[inline]
-    fn new(_features: ()) -> Self {
+    fn new(_plugin_uri: &Uri,
+        _sample_rate: f64,
+        _bundle_path: &CStr, _features: ()) -> Self {
         Amp
     }
 
@@ -28,7 +37,9 @@ impl Plugin for Amp {
     fn run(&mut self, ports: &AmpPorts) {
         let coef = db_co(ports.gain.value());
 
-        ports.output.collect_from(ports.input.iter().map(|v| *v * coef));
+        ports
+            .output
+            .collect_from(ports.input.iter().map(|v| *v * coef));
     }
 }
 


### PR DESCRIPTION
My main goal is to improve the `Plugin::instantiate` implementation: First, information like the frame rate, the bundle path or the URI of the plugin should be passed to the plugin. Therefore, I needed to extend the trait as well as the `Plugin::instantiate` implementation; Both reside in lv2-core/src/plugin/plugin.rs. While I was at it, I also updated the error management: In short, you already did the right thing: If the plugin can't be instantiated, the instantiate method should simply return a null pointer, that's expected behavior (as noted in the [spec](http://lv2plug.in/doc/html/group__lv2core.html#a8dbb1fd9ebae0477a11dfc4f0a685d72)).

Lastly, I accidentally ran `cargo fmt`. It did a lot of things, but I don't think that having consistent code formatting is a bad thing, isn't it?