### PR TITLE
Use a single struct to hold all plugin instanciation information

### DIFF
--- a/core/src/plugin/info.rs
+++ b/core/src/plugin/info.rs
@@ -1,0 +1,79 @@
+use crate::uri::{Uri, UriError};
+use std::ffi::CStr;
+use std::os::raw::c_char;
+use std::path::Path;
+use std::str::Utf8Error;
+
+#[derive(Debug)]
+#[doc(hidden)]
+pub(crate) enum PluginInfoError {
+    InvalidPluginUri(UriError),
+    InvalidBundlePathUtf8(Utf8Error),
+}
+
+/// Holds various data that is passed from the host at plugin instantiation time.
+///
+/// See the methods' documentation to know which data is available.
+pub struct PluginInfo<'a> {
+    plugin_uri: &'a Uri,
+    bundle_path: &'a Path,
+    sample_rate: f64,
+}
+
+impl<'a> PluginInfo<'a> {
+    #[doc(hidden)]
+    pub(crate) unsafe fn from_raw(
+        plugin_descriptor: *const crate::sys::_LV2_Descriptor,
+        bundle_path: *const c_char,
+        sample_rate: f64,
+    ) -> Result<Self, PluginInfoError> {
+        Self::new(
+            CStr::from_ptr((*plugin_descriptor).URI),
+            CStr::from_ptr(bundle_path),
+            sample_rate,
+        )
+    }
+
+    #[doc(hidden)]
+    pub(crate) fn new(
+        plugin_uri: &'a CStr,
+        bundle_path: &'a CStr,
+        sample_rate: f64,
+    ) -> Result<Self, PluginInfoError> {
+        let plugin_uri = Uri::from_cstr(plugin_uri).map_err(PluginInfoError::InvalidPluginUri)?;
+
+        let bundle_path = Path::new(
+            bundle_path
+                .to_str()
+                .map_err(PluginInfoError::InvalidBundlePathUtf8)?,
+        );
+
+        Ok(Self {
+            sample_rate,
+            plugin_uri,
+            bundle_path,
+        })
+    }
+
+    /// The URI of the plugin that is being instantiated.
+    #[inline]
+    pub fn plugin_uri(&self) -> &Uri {
+        self.plugin_uri
+    }
+
+    /// The path to the LV2 bundle directory which contains this plugin binary.
+    ///
+    /// This is useful to get if the plugin needs to store extra resources in its bundle directory,
+    /// such as presets, or any other kind of data.
+    #[inline]
+    pub fn bundle_path(&self) -> &Path {
+        self.bundle_path
+    }
+
+    /// The sample rate, in Hz, that is being used by the host.
+    /// The host will always send audio data to the plugin at this sample rate.
+    #[inline]
+    pub fn sample_rate(&self) -> f64 {
+        self.sample_rate
+    }
+}

--- a/tests/amp.rs
+++ b/tests/amp.rs
@@ -1,8 +1,6 @@
-use std::ffi::CStr;
-
 use lv2::core::plugin::{lv2_descriptors, InputPort, Lv2Ports, OutputPort, Plugin};
 use lv2::core::port::{Audio, Control};
-use lv2::core::uri::Uri;
+use lv2_core::plugin::PluginInfo;
 
 struct Amp;
 
@@ -27,7 +25,7 @@ impl Plugin for Amp {
     type Features = ();
 
     #[inline]
-    fn new(_plugin_uri: &Uri, _sample_rate: f64, _bundle_path: &CStr, _features: ()) -> Self {
+    fn new(_plugin_info: &PluginInfo, _features: ()) -> Self {
         Amp
     }
 

--- a/tests/amp.rs
+++ b/tests/amp.rs
@@ -1,6 +1,5 @@
-use lv2::core::plugin::{lv2_descriptors, InputPort, Lv2Ports, OutputPort, Plugin};
+use lv2::core::plugin::{lv2_descriptors, InputPort, Lv2Ports, OutputPort, Plugin, PluginInfo};
 use lv2::core::port::{Audio, Control};
-use lv2_core::plugin::PluginInfo;
 
 struct Amp;
 


### PR DESCRIPTION
The plugin's `new` function now takes three extra parameters that are data given from the host, which may or may not be used.
I put all of these in a single struct, for the following reasons:

- It makes it so you don't have to list and import all of the arguments if you don't use them (`Uri`, `CStr`, `Path`)
- It avoids leaking implementation details in the signature of this method of the trait (I also changed `bundle_path` to a `&Path` instead of a `&CStr`, so it can be used directly from Rust code to access the bundle without converting it first).
- It allows to add more data, fields or helpers to the instantiation function without it being a breaking change.

However I am aware that `PluginInfo` is not a good name for this struct, it is definitely up for bikeshedding. :slightly_smiling_face: 