### PR TITLE
Removing hand-written URI constants with `UriBounds`

### DIFF
--- a/core/src/extension_data.rs
+++ b/core/src/extension_data.rs
@@ -1,14 +1,7 @@
-use crate::uri::Uri;
+use crate::uri::UriBound;
 
 /// Represents extension data for a given feature, as returned by the `extension_data()` plugin's method.
 /// # Unsafety
 /// Since extension data is passed to plugin as a raw pointer,
 /// structs implementing this trait must be `#[repr(C)]`.
-pub unsafe trait ExtensionData: Sized {
-    const URI: &'static [u8];
-
-    #[inline]
-    fn uri() -> &'static Uri {
-        unsafe { Uri::from_bytes_unchecked(Self::URI) }
-    }
-}
+pub unsafe trait ExtensionData: Sized + UriBound {}

--- a/core/src/feature/mod.rs
+++ b/core/src/feature/mod.rs
@@ -8,42 +8,39 @@ use crate::feature::descriptor::FeatureDescriptor;
 use crate::uri::UriBound;
 
 /// Represents extension data for a given feature.
-/// # Unsafety
-/// Since extension data is passed to plugin as a raw pointer,
-/// structs implementing this trait must be `#[repr(C)]`.
-pub unsafe trait Feature: Sized + Copy {
-    const URI: &'static [u8];
-
+pub trait Feature: Sized + Copy + UriBound {
     #[inline]
     fn descriptor(&self) -> FeatureDescriptor {
         FeatureDescriptor::from_feature(self)
     }
 }
 
-unsafe impl<F: Feature> UriBound for F {
-    const URI: &'static [u8] = <F as Feature>::URI;
-}
-
 #[repr(C)]
 #[derive(Copy, Clone, Default)]
 pub struct HardRTCapable;
 
-unsafe impl Feature for HardRTCapable {
+unsafe impl UriBound for HardRTCapable {
     const URI: &'static [u8] = ::lv2_core_sys::LV2_CORE__hardRTCapable;
 }
+
+impl Feature for HardRTCapable {}
 
 #[repr(C)]
 #[derive(Copy, Clone, Default)]
 pub struct InPlaceBroken;
 
-unsafe impl Feature for InPlaceBroken {
+unsafe impl UriBound for InPlaceBroken {
     const URI: &'static [u8] = ::lv2_core_sys::LV2_CORE__inPlaceBroken;
 }
+
+impl Feature for InPlaceBroken {}
 
 #[repr(C)]
 #[derive(Copy, Clone, Default)]
 pub struct IsLive;
 
-unsafe impl Feature for IsLive {
+unsafe impl UriBound for IsLive {
     const URI: &'static [u8] = ::lv2_core_sys::LV2_CORE__isLive;
 }
+
+impl Feature for IsLive {}

--- a/core/src/feature/mod.rs
+++ b/core/src/feature/mod.rs
@@ -8,7 +8,10 @@ use crate::feature::descriptor::FeatureDescriptor;
 use crate::uri::UriBound;
 
 /// Represents extension data for a given feature.
-pub trait Feature: Sized + Copy + UriBound {
+///
+/// Features have to be `#[repr(C)]`, since they have to have a valid representation in C. Since
+/// this requirement can not be checked with super-traits, this trait is `unsafe` to implement.
+pub unsafe trait Feature: Sized + Copy + UriBound {
     #[inline]
     fn descriptor(&self) -> FeatureDescriptor {
         FeatureDescriptor::from_feature(self)
@@ -23,7 +26,7 @@ unsafe impl UriBound for HardRTCapable {
     const URI: &'static [u8] = ::lv2_core_sys::LV2_CORE__hardRTCapable;
 }
 
-impl Feature for HardRTCapable {}
+unsafe impl Feature for HardRTCapable {}
 
 #[repr(C)]
 #[derive(Copy, Clone, Default)]
@@ -33,7 +36,7 @@ unsafe impl UriBound for InPlaceBroken {
     const URI: &'static [u8] = ::lv2_core_sys::LV2_CORE__inPlaceBroken;
 }
 
-impl Feature for InPlaceBroken {}
+unsafe impl Feature for InPlaceBroken {}
 
 #[repr(C)]
 #[derive(Copy, Clone, Default)]
@@ -43,4 +46,4 @@ unsafe impl UriBound for IsLive {
     const URI: &'static [u8] = ::lv2_core_sys::LV2_CORE__isLive;
 }
 
-impl Feature for IsLive {}
+unsafe impl Feature for IsLive {}

--- a/core/src/port/audio.rs
+++ b/core/src/port/audio.rs
@@ -2,13 +2,17 @@ use crate::port::{
     base::{InputSampledData, OutputSampledData},
     PortType,
 };
+use crate::uri::UriBound;
 use std::ptr::NonNull;
 
 pub struct Audio;
 
+unsafe impl UriBound for Audio {
+    const URI: &'static [u8] = ::lv2_core_sys::LV2_CORE__AudioPort;
+}
+
 impl PortType for Audio {
     const NAME: &'static str = "Audio";
-    const URI: &'static [u8] = ::lv2_core_sys::LV2_CORE__AudioPort;
 
     type InputPortType = InputSampledData<f32>;
     type OutputPortType = OutputSampledData<f32>;

--- a/core/src/port/control.rs
+++ b/core/src/port/control.rs
@@ -1,4 +1,5 @@
 use crate::port::PortType;
+use crate::uri::UriBound;
 use std::ptr::NonNull;
 
 pub struct Control {
@@ -11,9 +12,12 @@ impl Control {
     }
 }
 
+unsafe impl UriBound for Control {
+    const URI: &'static [u8] = ::lv2_core_sys::LV2_CORE__ControlPort;
+}
+
 impl PortType for Control {
     const NAME: &'static str = "Control";
-    const URI: &'static [u8] = ::lv2_core_sys::LV2_CORE__ControlPort;
 
     type InputPortType = Self;
     type OutputPortType = Self;

--- a/core/src/port/cv.rs
+++ b/core/src/port/cv.rs
@@ -2,13 +2,17 @@ use crate::port::{
     base::{InputSampledData, OutputSampledData},
     PortType,
 };
+use crate::uri::UriBound;
 use std::ptr::NonNull;
 
 pub struct CV;
 
+unsafe impl UriBound for CV {
+    const URI: &'static [u8] = ::lv2_core_sys::LV2_CORE__CVPort;
+}
+
 impl PortType for CV {
     const NAME: &'static str = "CV";
-    const URI: &'static [u8] = ::lv2_core_sys::LV2_CORE__CVPort;
 
     type InputPortType = InputSampledData<f32>;
     type OutputPortType = OutputSampledData<f32>;

--- a/core/src/port/mod.rs
+++ b/core/src/port/mod.rs
@@ -2,7 +2,7 @@ mod audio;
 mod control;
 mod cv;
 
-use crate::uri::Uri;
+use crate::uri::{Uri, UriBound};
 use std::ptr::NonNull;
 
 pub mod base;
@@ -11,9 +11,8 @@ pub use self::audio::*;
 pub use self::control::*;
 pub use self::cv::*;
 
-pub trait PortType: 'static + Sized {
+pub trait PortType: 'static + Sized + UriBound {
     const NAME: &'static str;
-    const URI: &'static [u8];
 
     type InputPortType: Sized;
     type OutputPortType: Sized;


### PR DESCRIPTION
I've noticed that there are many (three) traits that also include a URI constant. In one case, `UriBound` is implemented for all implementors of that trait, but in all of the other cases, not. I therefore remove the `URI` constants from these traits and added `UriBound` as a super-trait. This should be a bit cleaner and easier to detect by RLS.