### PR TITLE
Documenting the macros and renaming several things

### DIFF
--- a/core/derive/Cargo.toml
+++ b/core/derive/Cargo.toml
@@ -9,3 +9,6 @@ proc-macro = true
 [dependencies]
 syn = "0.15.22"
 quote = "0.6.10"
+
+[dev-dependencies]
+lv2-core = { path = "../" }

--- a/core/derive/src/lib.rs
+++ b/core/derive/src/lib.rs
@@ -1,3 +1,4 @@
+//! Procedural macros for `lv2-core`.
 #![recursion_limit = "128"]
 
 extern crate proc_macro;
@@ -10,11 +11,13 @@ mod lv2_ports_derive;
 
 use proc_macro::TokenStream;
 
+/// Generate external symbols for LV2 plugins.
 #[proc_macro]
 pub fn lv2_descriptors(input: TokenStream) -> TokenStream {
     lv2_descriptors::lv2_descriptors_impl(input)
 }
 
+/// Implement the `Lv2Ports` trait for a port struct.
 #[proc_macro_derive(Lv2Ports)]
 pub fn lv2_ports_derive(input: TokenStream) -> TokenStream {
     lv2_ports_derive::lv2_ports_derive_impl(input)

--- a/core/derive/src/lib.rs
+++ b/core/derive/src/lib.rs
@@ -7,7 +7,7 @@ extern crate syn;
 extern crate quote;
 
 mod lv2_descriptors;
-mod lv2_ports_derive;
+mod port_container_derive;
 
 use proc_macro::TokenStream;
 
@@ -17,8 +17,8 @@ pub fn lv2_descriptors(input: TokenStream) -> TokenStream {
     lv2_descriptors::lv2_descriptors_impl(input)
 }
 
-/// Implement the `Lv2Ports` trait for a port struct.
-#[proc_macro_derive(Lv2Ports)]
-pub fn lv2_ports_derive(input: TokenStream) -> TokenStream {
-    lv2_ports_derive::lv2_ports_derive_impl(input)
+/// Implement the `PortContainer` trait for a port struct.
+#[proc_macro_derive(PortContainer)]
+pub fn port_container_derive(input: TokenStream) -> TokenStream {
+    port_container_derive::port_container_derive_impl(input)
 }

--- a/core/derive/src/lv2_descriptors.rs
+++ b/core/derive/src/lv2_descriptors.rs
@@ -3,6 +3,7 @@ use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;
 use syn::{parse_macro_input, LitStr, Result, Token, Type};
 
+/// A plugin that should be exported with a descriptor.
 struct Lv2DescriptorItem {
     plugin_type: Type,
     uri: LitStr,
@@ -18,6 +19,11 @@ impl Parse for Lv2DescriptorItem {
 }
 
 impl Lv2DescriptorItem {
+    /// Implement the `PluginInstanceDescriptor` for the plugin.
+    ///
+    /// By implementing `PluginInstanceDescriptor`, two static objects are created: The URI of the
+    /// plugin, stored as a string, and the descriptor, a struct with pointers to the plugin's
+    /// basic functions; Like `instantiate` or `run`.
     pub fn make_instance_descriptor(&self) -> impl ::quote::ToTokens {
         let plugin_type = &self.plugin_type;
         let uri = &self.uri;
@@ -41,6 +47,11 @@ impl Lv2DescriptorItem {
         }
     }
 
+    /// Create a matching arm for the plugin.
+    ///
+    /// The root function receives an index and has to return one plugin descriptor per index,
+    /// or NULL. In this crate's implementation, this index is matched in a `match` statement and
+    /// this method creates a match arm for this plugin.
     fn make_index_matcher(&self, index: u32) -> impl ::quote::ToTokens {
         let plugin_type = &self.plugin_type;
         quote! {

--- a/core/derive/src/lv2_ports_derive.rs
+++ b/core/derive/src/lv2_ports_derive.rs
@@ -4,27 +4,31 @@ use syn::DeriveInput;
 use syn::Field;
 use syn::{parse_macro_input, Data, DataStruct, Ident, Type};
 
-struct Lv2PortField<'a> {
+/// A field in the struct we implement `Lv2Ports` for.
+struct Lv2PortsField<'a> {
     identifier: &'a Ident,
     port_type: &'a Type,
 }
 
-impl<'a> Lv2PortField<'a> {
+impl<'a> Lv2PortsField<'a> {
+    /// Create a `Self` instance from a field object.
     fn from_input_field(input: &'a Field) -> Self {
-        Self {
+        Lv2PortsField {
             identifier: input.ident.as_ref().unwrap(),
             port_type: &input.ty,
         }
     }
 
+    /// Create the field initialization line for the implementing struct.
     fn make_connection_from_raw(&self) -> impl ::quote::ToTokens {
         let identifier = self.identifier;
-        let port_type = self.port_type; // Todo: check types implements PortHandle
+        let port_type = self.port_type;
         quote! {
             #identifier: <#port_type as ::lv2_core::plugin::PortHandle>::from_raw(connections.#identifier, sample_count),
         }
     }
 
+    /// Create the corresponding field declaration line for the raw pointer struct.
     fn make_raw_field_declaration(&self) -> impl ::quote::ToTokens {
         let identifier = self.identifier;
         quote! {
@@ -32,6 +36,7 @@ impl<'a> Lv2PortField<'a> {
         }
     }
 
+    /// Create the corresponding field initialization line for the raw pointer struct.
     fn make_raw_field_initialization(&self) -> impl ::quote::ToTokens {
         let identifier = self.identifier;
         quote! {
@@ -39,6 +44,7 @@ impl<'a> Lv2PortField<'a> {
         }
     }
 
+    /// Create the connection matching arm for the raw pointer struct.
     fn make_connect_matcher(&self, index: u32) -> impl ::quote::ToTokens {
         let identifier = self.identifier;
         quote! {
@@ -47,12 +53,17 @@ impl<'a> Lv2PortField<'a> {
     }
 }
 
-struct Lv2PortsFields<'a> {
+/// Representation of a struct we implement `Lv2Ports` for.
+///
+/// The implementation creates a hidden, mirrored version of the implementing struct that contains  
+/// the raw pointers for the port. Then, the ports object is created from the raw version.
+struct Lv2PortsStruct<'a> {
     struct_name: &'a Ident,
-    fields: Vec<Lv2PortField<'a>>,
+    fields: Vec<Lv2PortsField<'a>>,
 }
 
-impl<'a> Lv2PortsFields<'a> {
+impl<'a> Lv2PortsStruct<'a> {
+    /// Return an `Ident` for the internal module name.
     fn internal_mod_name(&self) -> Ident {
         Ident::new(
             &format!("__lv2_plugin_ports_derive_{}", self.struct_name),
@@ -60,20 +71,22 @@ impl<'a> Lv2PortsFields<'a> {
         )
     }
 
+    /// Construct a `Self` instance from a `DeriveInput`.
     fn from_derive_input(input: &'a DeriveInput) -> Self {
         let struct_name = &input.ident;
         let fields = match &input.data {
-            Data::Enum(_) | Data::Union(_) => unimplemented!(),
+            Data::Enum(_) | Data::Union(_) => panic!("Only structs can implement Lv2Ports"),
             Data::Struct(DataStruct { fields, .. }) => {
-                fields.iter().map(Lv2PortField::from_input_field).collect()
+                fields.iter().map(Lv2PortsField::from_input_field).collect()
             }
         };
-        Self {
+        Lv2PortsStruct {
             struct_name,
             fields,
         }
     }
 
+    /// Implement `Lv2Ports` for the struct.
     fn make_derived_contents(&self) -> TokenStream {
         let struct_name = self.struct_name;
         let internal_mod_name = self.internal_mod_name();
@@ -81,15 +94,15 @@ impl<'a> Lv2PortsFields<'a> {
         let connections_from_raw = self
             .fields
             .iter()
-            .map(Lv2PortField::make_connection_from_raw);
+            .map(Lv2PortsField::make_connection_from_raw);
         let raw_field_declarations = self
             .fields
             .iter()
-            .map(Lv2PortField::make_raw_field_declaration);
+            .map(Lv2PortsField::make_raw_field_declaration);
         let raw_field_inits = self
             .fields
             .iter()
-            .map(Lv2PortField::make_raw_field_initialization);
+            .map(Lv2PortsField::make_raw_field_initialization);
         let connect_matchers = self
             .fields
             .iter()
@@ -139,9 +152,10 @@ impl<'a> Lv2PortsFields<'a> {
     }
 }
 
+/// Implement `Lv2Ports` for a struct.
 #[inline]
 pub fn lv2_ports_derive_impl(input: TokenStream) -> TokenStream {
     let input: DeriveInput = parse_macro_input!(input);
-    let list = Lv2PortsFields::from_derive_input(&input);
+    let list = Lv2PortsStruct::from_derive_input(&input);
     list.make_derived_contents()
 }

--- a/tests/amp.rs
+++ b/tests/amp.rs
@@ -1,9 +1,11 @@
-use lv2::core::plugin::{lv2_descriptors, InputPort, Lv2Ports, OutputPort, Plugin, PluginInfo};
+use lv2::core::plugin::{
+    lv2_descriptors, InputPort, OutputPort, Plugin, PluginInfo, PortContainer,
+};
 use lv2::core::port::{Audio, Control};
 
 struct Amp;
 
-#[derive(Lv2Ports)]
+#[derive(PortContainer)]
 struct AmpPorts {
     gain: InputPort<Control>,
     input: InputPort<Audio>,


### PR DESCRIPTION
We should start to test and document your code now. First, I picked up the macro code, because this is the part I'm least familiar with. I've learned quite a bit from it and I hope that the descriptions are correct and without typos!

I also thought about the names for related things and renamed some internal stuff for the macros. However, I did not like the name `Lv2Ports`, especially because it contains a mention of LV2. Therefore, I renamed it into `PortContainer`, which I find more descriptive and style-fitting.