### PR TITLE
Alternative implementation of extension support

### DIFF
--- a/core/src/extension_data.rs
+++ b/core/src/extension_data.rs
@@ -1,7 +1,0 @@
-use crate::uri::UriBound;
-
-/// Represents extension data for a given feature, as returned by the `extension_data()` plugin's method.
-/// # Unsafety
-/// Since extension data is passed to plugin as a raw pointer,
-/// structs implementing this trait must be `#[repr(C)]`.
-pub unsafe trait ExtensionData: Sized + UriBound {}

--- a/core/src/feature/descriptor.rs
+++ b/core/src/feature/descriptor.rs
@@ -48,7 +48,7 @@ impl<'a> FeatureDescriptor<'a> {
     pub fn uri(&self) -> &Uri {
         unsafe {
             let slice = ::std::slice::from_raw_parts(self.inner.URI as *const u8, self.uri_len);
-            Uri::from_bytes_unchecked(slice)
+            Uri::from_bytes_with_nul_unchecked(slice)
         }
     }
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -9,6 +9,24 @@ pub mod uri;
 pub use self::feature::*;
 pub use self::port::*;
 
+/// Generate export symbols for an extension trait.
+///
+/// The [`export_extension_interfaces`](macro.export_extension_interfaces.html) requires some symbols from a trait in order to work. This macro creates these symbols. In order to work, this macro needs the URI of the interface, the type of the interface and an expression that constructs the interface. An example on how to use this macro:
+///
+///     use lv2_core::make_extension_interface;
+///
+///     unsafe extern "C" fn add(a: u32, b: u32) -> u32 {
+///         a+b
+///     }
+///
+///     #[repr(C)]
+///     struct Interface {
+///         add: unsafe extern "C" fn(a: u32, b: u32) -> u32,
+///     }
+///
+///     make_extension_interface!(b"urn:interface\0", Interface, Interface { add: add });
+///
+/// If you look for a proper example, take a look at the `extension` test.
 #[macro_export]
 macro_rules! make_extension_interface {
     ($uri:expr, $interface:ty, $instance:expr) => {
@@ -21,6 +39,12 @@ macro_rules! make_extension_interface {
     };
 }
 
+/// Generate a implementation for a plugin's
+/// [`extension_data`](plugin/trait.Plugin.html#method.extension_data) function.
+///
+/// This macro creates an implementation for `extension_data` that exports all extension interfaces
+/// that are build with the [`make_extension_interface`](macro.make_extension_interface.html)
+/// macro. Take a look at the `extension` test for an example!
 #[macro_export]
 macro_rules! export_extension_interfaces {
     ($($extension:ident),*) => {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,12 +1,33 @@
 pub extern crate lv2_core_sys as sys;
 
-mod extension_data;
 mod feature;
 
 pub mod plugin;
 pub mod port;
 pub mod uri;
 
-pub use self::extension_data::*;
 pub use self::feature::*;
 pub use self::port::*;
+
+#[macro_export]
+macro_rules! make_extension_interface {
+    ($uri:expr, $interface:ty, $instance:expr) => {
+        fn extension_uri() -> &'static ::lv2_core::uri::Uri {
+            const URI: &[u8] = $uri;
+            unsafe { ::lv2_core::uri::Uri::from_bytes_with_nul_unchecked(URI) }
+        }
+
+        const INTERFACE: $interface = $instance;
+    };
+}
+
+#[macro_export]
+macro_rules! export_extension_interfaces {
+    ($uri:expr, $($extension:ident),*) => {
+        $(
+        if <Self as $extension>::extension_uri() == $uri {
+            return Some(&<Self as $extension>::INTERFACE);
+        }
+        )*
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -23,11 +23,12 @@ macro_rules! make_extension_interface {
 
 #[macro_export]
 macro_rules! export_extension_interfaces {
-    ($uri:expr, $($extension:ident),*) => {
-        $(
-        if <Self as $extension>::extension_uri() == $uri {
-            return Some(&<Self as $extension>::INTERFACE);
+    ($($extension:ident),*) => {
+        fn extension_data(uri: &::lv2_core::uri::Uri) -> Option<&'static ::std::any::Any> {
+            $(if <Self as $extension>::extension_uri() == uri {
+                return Some(&<Self as $extension>::INTERFACE);
+            })*
+            None
         }
-        )*
     }
 }

--- a/core/src/plugin/mod.rs
+++ b/core/src/plugin/mod.rs
@@ -27,6 +27,20 @@ pub trait Plugin: Sized + Send + Sync {
     #[inline]
     fn deactivate(&mut self) {}
 
+    /// Return extension-specific data.
+    ///
+    /// There are some specifications for LV2 that require additional callback functions from the
+    /// plugin. These callbacks are usually implemented as traits other plugins can implement.
+    /// However, these additional functions have to be exported and this function is the usual way
+    /// to return them.
+    ///
+    /// The host calls this function for every extension interface it wants to have, with `uri` set
+    /// to the URI of the interface. Then, the plugin has to return the data required by the
+    /// specification, or `None` if it doesn't support the interface.
+    ///
+    /// Usually, you don't have to worry about implementing this on your own, because most
+    /// extension interfaces can be exported with the [`export_extension_interfaces`](../
+    /// macro.export_extension_interface.html) macro.
     fn extension_data(_uri: &Uri) -> Option<&'static Any> {
         None
     }

--- a/core/src/port/mod.rs
+++ b/core/src/port/mod.rs
@@ -22,7 +22,7 @@ pub trait PortType: 'static + Sized + UriBound {
 
     #[inline]
     fn uri() -> &'static Uri {
-        unsafe { Uri::from_bytes_unchecked(Self::URI) }
+        unsafe { Uri::from_bytes_with_nul_unchecked(Self::URI) }
     }
 }
 

--- a/core/src/uri.rs
+++ b/core/src/uri.rs
@@ -34,12 +34,17 @@ impl Uri {
     }
 
     #[inline]
+    pub unsafe fn from_ptr<'a>(ptr: *const i8) -> &'a Uri {
+        Uri::from_cstr_unchecked(CStr::from_ptr(ptr))
+    }
+
+    #[inline]
     pub unsafe fn from_cstr_unchecked(string: &CStr) -> &Uri {
         &*(string as *const CStr as *const Uri)
     }
 
     #[inline]
-    pub unsafe fn from_bytes_unchecked(bytes: &[u8]) -> &Uri {
+    pub unsafe fn from_bytes_with_nul_unchecked(bytes: &[u8]) -> &Uri {
         Uri::from_cstr_unchecked(CStr::from_bytes_with_nul_unchecked(bytes))
     }
 
@@ -240,6 +245,6 @@ pub unsafe trait UriBound {
 
     #[inline]
     fn uri() -> &'static Uri {
-        unsafe { Uri::from_bytes_unchecked(Self::URI) }
+        unsafe { Uri::from_bytes_with_nul_unchecked(Self::URI) }
     }
 }

--- a/tests/extension.rs
+++ b/tests/extension.rs
@@ -1,7 +1,5 @@
 use lv2::core::plugin::{lv2_descriptors, Plugin, PluginInfo};
-use lv2::core::uri::Uri;
 use lv2::core::{export_extension_interfaces, make_extension_interface};
-use std::any::Any;
 
 pub struct AddExtensionInterface {
     pub add: unsafe extern "C" fn(*const u32, usize) -> u32,
@@ -48,10 +46,7 @@ impl Plugin for ExtendedPlugin {
     #[inline]
     fn run(&mut self, _ports: &()) {}
 
-    fn extension_data(uri: &Uri) -> Option<&'static Any> {
-        export_extension_interfaces![uri, AddExtension];
-        None
-    }
+    export_extension_interfaces![AddExtension];
 }
 
 lv2_descriptors! {

--- a/tests/extension.rs
+++ b/tests/extension.rs
@@ -1,6 +1,10 @@
 use lv2::core::plugin::{lv2_descriptors, Plugin, PluginInfo};
 use lv2::core::{export_extension_interfaces, make_extension_interface};
 
+// #############
+// The extension
+// #############
+
 pub struct AddExtensionInterface {
     pub add: unsafe extern "C" fn(*const u32, usize) -> u32,
 }
@@ -21,6 +25,10 @@ pub trait AddExtension {
         }
     ];
 }
+
+// ##########
+// The plugin
+// ##########
 
 pub struct ExtendedPlugin {}
 
@@ -52,6 +60,10 @@ impl Plugin for ExtendedPlugin {
 lv2_descriptors! {
     ExtendedPlugin: "urn:extended-plugin"
 }
+
+// #######
+// Testing
+// #######
 
 #[test]
 fn test_extension() {

--- a/tests/extension.rs
+++ b/tests/extension.rs
@@ -1,0 +1,80 @@
+use lv2::core::plugin::{lv2_descriptors, Plugin, PluginInfo};
+use lv2::core::uri::Uri;
+use lv2::core::{export_extension_interfaces, make_extension_interface};
+use std::any::Any;
+
+pub struct AddExtensionInterface {
+    pub add: unsafe extern "C" fn(*const u32, usize) -> u32,
+}
+
+pub trait AddExtension {
+    fn sum(data: &[u32]) -> u32;
+
+    unsafe extern "C" fn extern_add(data: *const u32, len: usize) -> u32 {
+        let data: &[u32] = std::slice::from_raw_parts(data, len);
+        Self::sum(data)
+    }
+
+    make_extension_interface![
+        b"urn:MyExtension#interface\0",
+        AddExtensionInterface,
+        AddExtensionInterface {
+            add: Self::extern_add,
+        }
+    ];
+}
+
+pub struct ExtendedPlugin {}
+
+impl AddExtension for ExtendedPlugin {
+    fn sum(data: &[u32]) -> u32 {
+        let mut sum = 0;
+        for number in data {
+            sum += number
+        }
+        sum
+    }
+}
+
+impl Plugin for ExtendedPlugin {
+    type Ports = ();
+    type Features = ();
+
+    #[inline]
+    fn new(_plugin_info: &PluginInfo, _features: ()) -> Self {
+        ExtendedPlugin {}
+    }
+
+    #[inline]
+    fn run(&mut self, _ports: &()) {}
+
+    fn extension_data(uri: &Uri) -> Option<&'static Any> {
+        export_extension_interfaces![uri, AddExtension];
+        None
+    }
+}
+
+lv2_descriptors! {
+    ExtendedPlugin: "urn:extended-plugin"
+}
+
+#[test]
+fn test_extension() {
+    use lv2::core::sys::LV2_Descriptor;
+
+    let descriptor: &'static LV2_Descriptor = unsafe { lv2_descriptor(0).as_ref() }.unwrap();
+    let extension_data_fn = descriptor.extension_data.unwrap();
+
+    let interface: *const std::ffi::c_void =
+        unsafe { extension_data_fn(b"urn:MyExtension#interface\0".as_ptr() as *const i8) };
+    let interface: &'static AddExtensionInterface =
+        unsafe { (interface as *const AddExtensionInterface).as_ref() }.unwrap();
+
+    let length: usize = 256;
+    let mut data: Vec<u32> = Vec::with_capacity(length);
+    for _ in 0..length {
+        data.push(1);
+    }
+
+    unsafe { assert_eq!((interface.add)(data.as_ptr(), length), length as u32) };
+}

--- a/tests/extension.rs
+++ b/tests/extension.rs
@@ -5,6 +5,7 @@ use lv2::core::{export_extension_interfaces, make_extension_interface};
 // The extension
 // #############
 
+#[repr(C)]
 pub struct AddExtensionInterface {
     pub add: unsafe extern "C" fn(*const u32, usize) -> u32,
 }


### PR DESCRIPTION
I've made my own thoughts on the extension support and this is what I came up with!

The main difference is that there is no proper abstraction of extensions: An extension is simply a trait that has some special symbols that are used to export the interface with a `extension_data` function. Both the "special symbols" and a `extension_data` implementation can be generated with a macro. My reason for not having a proper abstraction of extensions is that you can not really abstract traits:

You can only implement a trait for a proper type or a trait object, not for a trait itself (meaning that the implemented methods are simply added to the trait). Trying to circumnavigate these shortcomings doesn't really lead to a nice, somewhat idiomatic solution and therefore, I used the simplest one!

The resulting code is short, relatively easy to understand and it works. I therefore hope that you like my approach!